### PR TITLE
fix macos build error

### DIFF
--- a/cmake_modules/Commons.cmake
+++ b/cmake_modules/Commons.cmake
@@ -25,7 +25,7 @@ macro(set_common_cxx_flags_for_redex)
 endmacro()
 
 macro(add_dependent_packages_for_redex)
-    find_package(Boost 1.56.0 REQUIRED COMPONENTS regex filesystem program_options iostreams thread)
+    find_package(Boost 1.56.0 REQUIRED COMPONENTS system regex filesystem program_options iostreams thread)
     print_dirs("${Boost_INCLUDE_DIRS}" "Boost_INCLUDE_DIRS")
     print_dirs("${Boost_LIBRARIES}" "Boost_LIBRARIES")
 


### PR DESCRIPTION
Undefined symbols for architecture x86_64:
  "boost::system::system_category()", referenced from:
      ___cxx_global_var_init.6 in libredex.a(CallGraph.cpp.o)
      ___cxx_global_var_init.6 in libredex.a(DexClass.cpp.o)
      ___cxx_global_var_init.6 in libredex.a(DexLoader.cpp.o)
      ___cxx_global_var_init.6 in libredex.a(DexOutput.cpp.o)
      ___cxx_global_var_init.6 in libredex.a(DexUtil.cpp.o)
      ___cxx_global_var_init.6 in libredex.a(Inliner.cpp.o)